### PR TITLE
Set real pywikibot release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pywikibot==3.0.dev0
+pywikibot==3.0.20190722
 requests==2.20.0
 pyyaml>=4.2b1
 mwparserfromhell==0.5.2


### PR DESCRIPTION
3.0dev is ther internal pywikibot release name which does not
correspond to a version available on PyPI. As a result
`pip install -r requirements.txt` failed.