### PR TITLE
Add checklist to year pages

### DIFF
--- a/config.yaml.wmse
+++ b/config.yaml.wmse
@@ -41,6 +41,7 @@ wiki:
             Ansökningar <YEAR>: Mall:Ansökningar år
             Ekonomiska rapporter <YEAR>: Mall:Ekonomiska rapporter
             Ledningsrapport <YEAR>: Mall:Ledningsrapport år
+            Checklista för nytt år/<YEAR>: :Checklista för nytt år
         projects:
             title: Projekt <YEAR>
             template: Mall:Årsida för projekt


### PR DESCRIPTION
Note the leading colon, needed to use a page in the main namespace
as a template. The substed equivalent becomes `{{subst::Pagename}}