### PR TITLE
Add parameter "bot" to project pages, with a truthy value

### DIFF
--- a/wiki.py
+++ b/wiki.py
@@ -71,10 +71,12 @@ class Wiki:
             for template_parameter, label in project_parameters:
                 template.add_parameter(
                     template_parameter,
-                    parameters[self._project_columns[label]])
+                    parameters[self._project_columns[label]]
+                )
             template.add_parameter("year", self._year)
             template.add_parameter("phabricatorId", phab_id)
             template.add_parameter("phabricatorName", phab_name)
+            template.add_parameter("bot", "ja")
             content = "{}".format(template)
             page.text = content
             logging.info("Writing to project page '{}'".format(page.title()))


### PR DESCRIPTION
This is used by the checklist to only add the bullet points that
remain after the bot has added information.

Also fixed an annoying parenthesis.

Bug: T243897