### PR TITLE
Replace Phabricator API token with placeholder in logs

### DIFF
--- a/phab.py
+++ b/phab.py
@@ -129,13 +129,15 @@ class Phab:
             logging.debug("Waiting for {} seconds before making the next request to Conduit.".format(wait_time))  # noqa: E501
             sleep(wait_time)
         parameters = self._to_phab_parameters(parameters_dict)
-        parameters["api.token"] = self._config["api_token"]
+        # Add placeholder API token to not reveal the real one in logs.
+        parameters["api.token"] = "api-..."
         logging.debug(
             "POST to Phabricator API on {}: {}".format(
                 self._config["api_url"],
                 parameters
             )
         )
+        parameters["api.token"] = self._config["api_token"]
         self._last_request_time = time()
         response = requests.post(
             "{}/{}".format(self._config["api_url"], endpoint),

--- a/phab.py
+++ b/phab.py
@@ -130,11 +130,12 @@ class Phab:
             sleep(wait_time)
         parameters = self._to_phab_parameters(parameters_dict)
         # Add placeholder API token to not reveal the real one in logs.
-        parameters["api.token"] = "api-..."
+        logged_parameters = parameters.copy()
+        logged_parameters["api.token"] = "api-..."
         logging.debug(
             "POST to Phabricator API on {}: {}".format(
                 self._config["api_url"],
-                parameters
+                logged_parameters
             )
         )
         parameters["api.token"] = self._config["api_token"]


### PR DESCRIPTION
The token is represented by "api-..." in log outputs to make it safe
to share log files.

Bug: T241248