### PR TITLE
Sanitize input

### DIFF
--- a/project_start.py
+++ b/project_start.py
@@ -125,6 +125,7 @@ def sanitize(unsanitized):
     return sanitized
 
 
+def sanitize_string(unsanitized_string):
     """Sanitize a strings.
 
     * Strips leading and trailing whitespaces
@@ -139,7 +140,6 @@ def sanitize(unsanitized):
     string
         Sanitized string
     """
-def sanitize_string(unsanitized_string):
     sanitized_sring = unsanitized_string.strip()
     return sanitized_sring
 

--- a/project_start.py
+++ b/project_start.py
@@ -115,13 +115,12 @@ def sanitize(unsanitized):
     """
     sanitized = None
     if isinstance(unsanitized, dict):
-        sanitized = {}
-        for k, v in unsanitized.items():
-            sanitized[sanitize_string(k)] = sanitize_string(v)
+        sanitized = {
+            sanitize_string(k): sanitize_string(v) for
+            k, v in unsanitized.items()
+        }
     elif isinstance(unsanitized, list):
-        sanitized = []
-        for i in unsanitized:
-            sanitized.append(sanitize_string(i))
+        sanitized = [sanitize_string(i) for i in unsanitized]
     return sanitized
 
 


### PR DESCRIPTION
Initially strip leading and trailing whitespaces. Also, use
`newline=""` for open() calls, as by recommendation in the
documentation.

Bug: T241245