### PR TITLE
Select components to add

### DIFF
--- a/const.py
+++ b/const.py
@@ -1,0 +1,8 @@
+from enum import Enum
+from enum import auto
+
+
+class Components(Enum):
+    PROJECT_MAIN_PAGE = 1
+    PHABRICATOR = auto()
+    CATEGORIES = auto()

--- a/const.py
+++ b/const.py
@@ -1,5 +1,4 @@
-from enum import Enum
-from enum import auto
+from enum import Enum, auto
 
 
 class Components(Enum):

--- a/const.py
+++ b/const.py
@@ -3,6 +3,6 @@ from enum import auto
 
 
 class Components(Enum):
-    PROJECT_MAIN_PAGE = 1
+    PROJECT_MAIN_PAGE = auto()
     PHABRICATOR = auto()
     CATEGORIES = auto()

--- a/phab.py
+++ b/phab.py
@@ -48,7 +48,7 @@ class Phab:
         phab_name = self._to_phab_project_name(name, parent_name)
         project_id = self._get_project_id(phab_name)
         if project_id is not None:
-            logging.warn(
+            logging.warning(
                 "Project '{}' already exists. It will not be created.".format(
                     phab_name
                 )

--- a/project_start.py
+++ b/project_start.py
@@ -265,9 +265,11 @@ def process_project(project_information, project_columns):
         # Don't add anything for subprojects.
         return
     if goals and project_name not in goals:
-        logging.warn(
+        logging.warning(
             "Project name '{}' found in projects file, but not in goals file. "
-            "It will not be created.".format(project_name)
+            "It will not be created. If you tried to add components that "
+            "don't require goal information, run without the goal "
+            "file.".format(project_name)
         )
         return
     logging.info(
@@ -284,7 +286,8 @@ def process_project(project_information, project_columns):
         phab_id = phab_name = ""
     add_wiki_project_pages(project_information, project_columns,
                            phab_id, phab_name)
-    goals[project_name]["added"] = True
+    if goals:
+        goals[project_name]["added"] = True
     wiki.add_project(
         project_information[project_columns["project_number"]],
         project_information[project_columns["swedish_name"]],
@@ -451,7 +454,7 @@ if __name__ == "__main__":
                     )
         wiki.add_year_pages()
     elif not single_project_found:
-        logging.warn(
+        logging.warning(
             "Project name '{}' could not be found in projects file. "
             "It will not be created.".format(args.project)
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests==2.20.0
 pyyaml>=4.2b1
 mwparserfromhell==0.5.2
 wikitables==0.4.2
+tox>=3.24.5,==3.*

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,8 @@ ignore = W503 # line break before binary operator; against current PEP 8
 deps = isort==4.2.15
 commands =
     isort {posargs:--check-only --diff} --recursive --verbose \
-        --skip .git --skip .tox --skip .venv
+        --skip .git --skip .tox --skip .venv --skip user-config.py \
+        --skip user-password.py
 
 [isort]
 known_first_party =

--- a/wiki.py
+++ b/wiki.py
@@ -184,10 +184,10 @@ class Wiki:
             # Special case for goals parameters, as they are not
             # just copied.
             if not self._goals:
-                logging.error(
-                    ("Goals need to be supplied for page '{}', "
-                     "it will not be added.")
-                    .format(subpage["title"])
+                title = subpage["title"]
+                logging.warning(
+                    f"Goals need to be supplied for page '{title}', "
+                    "it will not be added."
                 )
                 return
 
@@ -512,6 +512,13 @@ class Wiki:
             self._make_year_title(
                 self._config["year_pages"]["operational_plan"])
         )
+        if not operational_plan_page.exists():
+            title = operational_plan_page.title()
+            raise Exception(
+                f"Page '{title}' doesn't exist and is required to create "
+                "this page."
+            )
+
         # Get table string. This assumes that it is the first table on
         # the page.
         table_string = str(mwp.parse(

--- a/wiki.py
+++ b/wiki.py
@@ -383,8 +383,8 @@ class Wiki:
         if not self._prompt_year_pages:
             return True
 
-        print('Add page "{}"? (y/N)'.format(self._make_year_title(title)))
-        return input().lower() == "y"
+        prompt = 'Add page "{}"? (y/N)'.format(self._make_year_title(title))
+        return input().lower(prompt) == "y"
 
     def _add_projects_year_page(self):
         """Create a page with a list of the year's projects.


### PR DESCRIPTION
Allows for selecting what to add for each project and general pages. The
flag `--components` shows a menu of project components. Only the
selected ones will be added for each processed project. The flag
`--prompt-add-pages` prompts before adding each general page, allowing
to skip pages.

Goals file is now only required if goal information is needed for the
selected pages.

Also:

* Added Tox to requirements.txt.
* Exclude Pywikibot files from Tox.

Bug: T297895