### PR TITLE
Bumping pywikibot to version which is installable via pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pywikibot==3.0.20190722
+pywikibot==3.0.20200111
 requests==2.20.0
 pyyaml>=4.2b1
 mwparserfromhell==0.5.2


### PR DESCRIPTION
Might be that later versions also work but a lot of breaking changes
were introduced between 3.0.20200111 and the current version (7.0)
so that is better investigated at a later time.