### PR TITLE
Update subpage name for 2023 onwards

### DIFF
--- a/config.yaml.wmse
+++ b/config.yaml.wmse
@@ -32,7 +32,7 @@ wiki:
           template_name: Mall:Frivillig-sida
           parameters:
               e-post_prefix: e_mail
-        - title: Metrics
+        - title: Resultat och mätetal
           template_name: Mall:Metrics-sida
         - title: Projektdata
           template_name: Projektdata-sida


### PR DESCRIPTION
Per internal discussions "Resultat och mätetal" was chosen instead
to clarify that the page is for more than just the metrics templates.