### PR TITLE
Update requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This bot adds initial information at the start of year for Wikimedia Sverige. It adds projects and year pages to our wiki (https://se.wikimedia.org) and to the Mediawiki Phabricator (https://phabricator.wikimedia.org). It runs with Python 3.8 or later.
+This bot adds initial information at the start of year for Wikimedia Sverige. It adds projects and year pages to our wiki (https://se.wikimedia.org) and to the Wikimedia Phabricator (https://phabricator.wikimedia.org). It runs with Python 3.8 or later.
 
 # Installation
 Install required libraries with pip:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This bot adds initial information at the start of year for Wikimedia Sverige. It adds projects and year pages to our wiki (https://se.wikimedia.org) and to the Mediawiki Phabricator (https://phabricator.wikimedia.org). It runs with Python 3.
+This bot adds initial information at the start of year for Wikimedia Sverige. It adds projects and year pages to our wiki (https://se.wikimedia.org) and to the Mediawiki Phabricator (https://phabricator.wikimedia.org). It runs with Python 3.8 or later.
 
 # Installation
 Install required libraries with pip:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-flake8
-isort
-tox
-yamllint
+flake8==6.0.0
+isort==5.12.0
+tox==4.5.1
+yamllint==1.32.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-pywikibot==3.0.20200111
-requests==2.20.0
-pyyaml>=4.2b1
-mwparserfromhell==0.5.2
-wikitables==0.4.2
-tox>=3.24.5,==3.*
+pywikibot==8.1.2
+pyyaml==6.0
+mwparserfromhell==0.6.4
+wikitables==0.5.5

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
 commands = nosetests {posargs}
 
 [testenv:flake8]
-deps = flake8==3.7.9
+deps = flake8==6.0.0
 commands = flake8
 
 [flake8]
@@ -24,7 +24,7 @@ exclude =
 ignore = W503 # line break before binary operator; against current PEP 8
 
 [testenv:isort]
-deps = isort==4.2.15
+deps = isort==5.12.0
 commands =
     isort {posargs:--check-only --diff} --recursive --verbose \
         --skip .git --skip .tox --skip .venv --skip user-config.py \
@@ -38,7 +38,7 @@ multi_line_output = 3
 sections = FUTURE,STDLIB,THIRDPARTY,PYWIKIBOT,FIRSTPARTY,LOCALFOLDER
 
 [testenv:yaml]
-deps = yamllint
+deps = yamllint==1.32.0
 commands =
     yamllint {toxinidir}/
 


### PR DESCRIPTION
Updated the required packages to current master version on PyPi. All packages now use exact versions to avoid inconsistencies. Removed `requests` since it's installed by `pywikibot`. Moved `tox` to testing requirements file.

Specified Python version as 3.8.