### PR TITLE
Allow running without goals file

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -54,7 +54,8 @@ wiki:
                   column: funder_2
               budget_2:
                   column: budget_2
-              dolt_läge: 1
+              dolt_läge:
+                  string: 1
           year_parameter: år
     year_pages:
         current_projects_template: Mall:Aktuella projekt <YEAR>

--- a/config.yaml
+++ b/config.yaml
@@ -36,8 +36,6 @@ wiki:
           template_name: Mall:Metrics-sida
         - title: Projektdata
           template_name: Projektdata-sida
-          add_goals_parameters:
-              interna_mål: Måltexter|<YEAR>
           parameters:
               ansvarig: lead
               projektstart: project_start

--- a/config.yaml
+++ b/config.yaml
@@ -25,25 +25,36 @@ wiki:
     project_namespace: Projekt
     project_template: Mall:Projekt-sida
     project_parameters:
-        beskrivning: about_swedish
-        samarbetspartners: partners
+        beskrivning:
+            column: about_swedish
+        samarbetspartners:
+            column: partners
     subpages:
         - title: Frivillig
           template_name: Mall:Frivillig-sida
           parameters:
-              e-post_prefix: e_mail
+              e-post_prefix:
+                  column: e_mail
         - title: Resultat och mätetal
           template_name: Mall:Metrics-sida
         - title: Projektdata
           template_name: Projektdata-sida
           parameters:
-              ansvarig: lead
-              projektstart: project_start
-              projektslut: project_end
-              finansiär: funder
-              budget: budget
-              finansiär_2: funder_2
-              budget_2: budget_2
+              ansvarig:
+                  column: lead
+              projektstart:
+                  column: project_start
+              projektslut:
+                  column: project_end
+              finansiär:
+                  column: funder
+              budget:
+                  column: budget
+              finansiär_2:
+                  column: funder_2
+              budget_2:
+                  column: budget_2
+              dolt_läge: 1
           year_parameter: år
     year_pages:
         current_projects_template: Mall:Aktuella projekt <YEAR>

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -23,8 +23,8 @@ wiki:
         # Parameter with string value.
         template_parameter_1:
             string: value
-        # Mapping between the parameter names in the project page template
-        # and the canonical label in project_columns above.
+        # Mapping between the parameter names in the project page
+        # template and the canonical label in project_columns above.
         template_parameter_2:
             column: label
     # A list of subpages that should be created under the project page.
@@ -33,7 +33,9 @@ wiki:
         - title:
           # Name of the template used to create subpage.
           template_name:
-          # Paramaters to pass to the subpage template. Uses the same formats as project_parameters.templates. Note that the "år"-parameter is always passed.
+          # Paramaters to pass to the subpage template. Uses the same
+          # formats as project_parameters.templates. Note that the
+          # "år"-parameter is always passed.
           parameters:
               template_parameter_1:
                   column: label

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -18,21 +18,27 @@ wiki:
     project_namespace:
     # Name of the template used to create the project page.
     project_template:
-    # Mapping between the parameter names in the project page template
-    # and the canonical label in project_columns above.
+    # Parameters to pass to the template.
     project_parameters:
-        template_parameter: label
+        # Parameter with string value.
+        template_parameter_1:
+            string: value
+        # Mapping between the parameter names in the project page template
+        # and the canonical label in project_columns above.
+        template_parameter_2:
+            column: label
     # A list of subpages that should be created under the project page.
     subpages:
         # Title of the subpage.
         - title:
           # Name of the template used to create subpage.
           template_name:
-          # Mapping between the parameter names in the subpage
-          # template and the canonical label in project_columns above.
-          # Note that the "år"-parameter is always passed.
+          # Paramaters to pass to the subpage template. Uses the same formats as project_parameters.templates. Note that the "år"-parameter is always passed.
           parameters:
-              template_parameter: label
+              template_parameter_1:
+                  column: label
+              template_parameter_2:
+                  string: value
           # Add this only if the subpage should include goals. If no
           # page has this parameter a goal file isn't required.
           add_goals_parameters:

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -33,7 +33,8 @@ wiki:
           # Note that the "år"-parameter is always passed.
           parameters:
               template_parameter: label
-          # Add this only if the subpage should include goals.
+          # Add this only if the subpage should include goals. If no
+          # page has this parameter a goal file isn't required.
           add_goals_parameters:
               # Template parameter where the goals template should be
               # put and the name of the template to use for the goals.

--- a/project_start.py
+++ b/project_start.py
@@ -363,7 +363,9 @@ def load_args():
     parser.add_argument(
         "goal_file",
         help=("Path to a file containing information about project goals. "
-              "The data should be tab separated values."),
+              "The data should be tab separated values. This parameter is "
+              "only needed if a subpage has the `add_goals_parameters` set "
+              "in the config."),
         nargs="?"
     )
     return parser.parse_args()

--- a/wiki.py
+++ b/wiki.py
@@ -221,23 +221,17 @@ class Wiki:
             template_parameters
         )
 
-    def _get_parameter_value(self, project_parameters, value):
-        # print(f"key = {key}")
-        # parameters = self._config["project_parameters"]
-        # value = parameters.get(key)
-        # print(f"project_parameters = {project_parameters}")
+    def _get_parameter_value(self, project_parameters, specification):
+        # Just get the first key and value since there should only be
+        # one.
+        value_type, value = list(specification.items())[0]
         print(f"value = {value}")
-        if isinstance(value, dict):
-            column = value.get("column")
-            if not column:
-                return None
-
-            label = self._project_columns.get(column)
+        if value_type == "string":
+            return value
+        elif value_type == "column":
+            label = self._project_columns.get(value)
             print(f"label = {label}")
-            print(f"column = {column}")
             return project_parameters.get(label)
-
-        return value
 
     def _add_page_from_template(
             self,

--- a/wiki.py
+++ b/wiki.py
@@ -128,10 +128,12 @@ class Wiki:
 
         template = Template(self._config["project_template"], True)
         project_parameters = self._config["project_parameters"].items()
-        for template_parameter, label in project_parameters:
+        for template_parameter, value in project_parameters:
+            # label = value.get("column")
             template.add_parameter(
                 template_parameter,
-                parameters[self._project_columns[label]]
+                self._get_parameter_value(parameters, template_parameter)
+                # parameters[self._project_columns[label]]
             )
         template.add_parameter("year", self._year)
         template.add_parameter("phabricatorId", phab_id)
@@ -176,10 +178,15 @@ class Wiki:
         # Always pass the year parameter.
         template_parameters = {"år": self._year}
         if "parameters" in subpage:
-            for key, label in subpage["parameters"].items():
-                template_parameters[key] = project_parameters[
-                    self._project_columns[label]
-                ]
+            for key, value in subpage["parameters"].items():
+                template_parameters[key] = self._get_parameter_value(project_parameters, key)
+            #     if isinstance(value, dict):
+            #         column = value.get("column")
+            #         template_parameters[key] = project_parameters.get(
+            #             self._project_columns.get(column)
+            #         )
+            #     else:
+            #         template_parameters[key] = value
         if "add_goals_parameters" in subpage:
             # Special case for goals parameters, as they are not
             # just copied.
@@ -211,6 +218,23 @@ class Wiki:
             subpage["template_name"],
             template_parameters
         )
+
+    def _get_parameter_value(self, columns, key):
+        print(f"key = {key}")
+        parameters = self._config["project_parameters"]
+        value = parameters.get(key)
+        print(f"value = {value}")
+        if isinstance(value, dict):
+            column = value.get("column")
+            if not column:
+                return None
+
+            label = self._project_columns.get(column)
+            print(f"label = {label}")
+            print(f"columns = {columns}")
+            return columns.get(label)
+
+        return value
 
     def _add_page_from_template(
             self,

--- a/wiki.py
+++ b/wiki.py
@@ -132,7 +132,7 @@ class Wiki:
             # label = value.get("column")
             template.add_parameter(
                 template_parameter,
-                self._get_parameter_value(parameters, template_parameter)
+                self._get_parameter_value(parameters, value)
                 # parameters[self._project_columns[label]]
             )
         template.add_parameter("year", self._year)
@@ -178,8 +178,9 @@ class Wiki:
         # Always pass the year parameter.
         template_parameters = {"år": self._year}
         if "parameters" in subpage:
+            # print(f"project_parameters = {project_parameters}")
             for key, value in subpage["parameters"].items():
-                template_parameters[key] = self._get_parameter_value(project_parameters, key)
+                template_parameters[key] = self._get_parameter_value(project_parameters, value)
             #     if isinstance(value, dict):
             #         column = value.get("column")
             #         template_parameters[key] = project_parameters.get(
@@ -187,6 +188,7 @@ class Wiki:
             #         )
             #     else:
             #         template_parameters[key] = value
+            print(template_parameters)
         if "add_goals_parameters" in subpage:
             # Special case for goals parameters, as they are not
             # just copied.
@@ -219,10 +221,11 @@ class Wiki:
             template_parameters
         )
 
-    def _get_parameter_value(self, columns, key):
-        print(f"key = {key}")
-        parameters = self._config["project_parameters"]
-        value = parameters.get(key)
+    def _get_parameter_value(self, project_parameters, value):
+        # print(f"key = {key}")
+        # parameters = self._config["project_parameters"]
+        # value = parameters.get(key)
+        # print(f"project_parameters = {project_parameters}")
         print(f"value = {value}")
         if isinstance(value, dict):
             column = value.get("column")
@@ -231,8 +234,8 @@ class Wiki:
 
             label = self._project_columns.get(column)
             print(f"label = {label}")
-            print(f"columns = {columns}")
-            return columns.get(label)
+            print(f"column = {column}")
+            return project_parameters.get(label)
 
         return value
 


### PR DESCRIPTION
If the config doesn't have `add_goals_parameters` for any of the subpages the goal file isn't needed. Template parameters in the config for project and subpage templates can be given as column labels or plain strings. Column labels uses the old behaviour, i.e. takes the value from that column for the project.

Bug: T352429