### PR TITLE
Show merge when overwriting wiki pages

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,4 @@ tox==4.5.1
 flake8==7.0.0
 yamllint==1.32.0
 isort==5.12.0
+pytest==7.4.4

--- a/tests/test_wiki.py
+++ b/tests/test_wiki.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest.mock import MagicMock
+
+import pywikibot
+from pywikibot import Page, Site
+from pywikibot.data.api import Request
+
+from wiki import Wiki
+
+
+class TestWiki(unittest.TestCase):
+
+    def setUp(self):
+        parameters = [None] * 9
+        self._wiki = Wiki(*parameters)
+
+    def test_write_page_exists_show_diff(self):
+        self._wiki._site = MagicMock(Site)
+        self._wiki._config = {"edit_summary": "edit_summary"}
+        page = MagicMock(Page)
+        page.exists = MagicMock(return_value=True)
+        page.get = MagicMock(return_value="Old text")
+        request = MagicMock(Request)
+        data = {"parse": {"text": {"*": "New text"}}}
+        request.submit = MagicMock(return_value=data)
+        self._wiki._site.simple_request = MagicMock(return_value=request)
+        pywikibot.diff.cherry_pick = MagicMock()
+
+        self._wiki._write_page(page)
+
+        pywikibot.diff.cherry_pick.assert_called_with("Old text", "New text")
+
+    def test_write_page_merged_text_saved(self):
+        self._wiki._site = MagicMock(Site)
+        self._wiki._config = {"edit_summary": "edit_summary"}
+        page = MagicMock(Page)
+        page.exists = MagicMock(return_value=True)
+        page.text = "Old text"
+        page.get = MagicMock(return_value="Old text")
+        self._wiki._site.simple_request = MagicMock()
+        merged_text = "Merged text"
+        pywikibot.diff.cherry_pick = MagicMock(return_value=merged_text)
+
+        self._wiki._write_page(page)
+
+        self.assertEqual(page.text, merged_text)
+        page.save.assert_called()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-env_list = flake8, yaml, isort
+env_list = pytest, flake8, yaml, isort
 no_package = true
 
 [testenv]
@@ -8,6 +8,10 @@ setenv =
     # Since pywikibot fallback to the user home directory:
     HOME={envdir}
 deps = -r requirements-test.txt
+
+[testenv:pytest]
+description = install pytest in a virtual environment and invoke it on the tests folder
+commands = pytest tests/
 
 [testenv:flake8]
 commands = flake8

--- a/wiki.py
+++ b/wiki.py
@@ -1,6 +1,7 @@
 import logging
 import re
 
+import pywikibot
 from pywikibot import Page, Site
 
 from const import Components
@@ -179,6 +180,19 @@ class Wiki:
             The page to write to.
 
         """
+        if page.exists():
+            request = self._site.simple_request(
+                action="parse",
+                title=page.title(),
+                text=page.text,
+                contentmodel="wikitext",
+                prop="",
+                onlypst=1
+            )
+            data = request.submit()
+            parsed_text = data['parse']['text']["*"]
+            page.text = pywikibot.diff.cherry_pick(page.get(), parsed_text)
+
         if not self._dry_run:
             page.save(summary=self._config["edit_summary"])
         self._touched_pages.append(page)


### PR DESCRIPTION
If a page would be overwritten the user is shown a merge prompt, allowing them to pick which parts to include in the text that is saved.

Introduces unit testing, but only adds tests for the new functionality.

Bug: T355681