### PR TITLE
Skip projects not marked as active

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,7 +19,7 @@ project_columns:
     budget_2: Budget 2
     partners: Partner
     super_project: Överprojekt
-    skip: Inaktiv
+    active: Aktiv
 wiki:
     edit_summary: Sidan skapad av [[Nyårsbot]]
     project_namespace: Projekt

--- a/project_start.py
+++ b/project_start.py
@@ -214,6 +214,10 @@ def get_goal_name(description):
     return description.split(" - ")[0]
 
 
+def is_active(project_information, project_columns):
+    return project_information.get(project_columns.get("active")) == "1"
+
+
 def add_wiki_project_pages(project_information, project_columns,
                            phab_id, phab_name):
     """Add a project page to the wiki.
@@ -436,7 +440,7 @@ if __name__ == "__main__":
                         project_information[project_columns["project_number"]],
                         project_information[project_columns["swedish_name"]]
                     )
-            elif project_information[project_columns["skip"]]:
+            elif not is_active(project_information, project_columns):
                 # handle skip outside of process_project to allow specifying a
                 # single project to override the skip value.
                 logging.info(

--- a/tests/test_project_start.py
+++ b/tests/test_project_start.py
@@ -1,0 +1,32 @@
+import unittest
+
+import project_start
+
+
+class TestProjectStart(unittest.TestCase):
+
+    def test_is_active_active(self):
+        project_information = {
+            "ACTIVE": "1"
+        }
+        project_columns = {
+            "active": "ACTIVE"
+        }
+
+        self.assertTrue(project_start.is_active(
+            project_information,
+            project_columns
+        ))
+
+    def test_is_active_inactive(self):
+        project_information = {
+            "ACTIVE": "0"
+        }
+        project_columns = {
+            "active": "ACTIVE"
+        }
+
+        self.assertFalse(project_start.is_active(
+            project_information,
+            project_columns
+        ))

--- a/wiki.py
+++ b/wiki.py
@@ -583,10 +583,16 @@ class Wiki:
 
         template = Template("Aktuella projekt/layout")
         template.add_parameter("år", self._year)
-        template.add_parameter("access", template_data["Tillgång"])
-        template.add_parameter("use", template_data["Användning"])
-        template.add_parameter("community", template_data["Gemenskapen"])
-        template.add_parameter("enabling", template_data["Möjliggörande"])
+        template.add_parameter("access", template_data.get("Tillgång", ""))
+        template.add_parameter("use", template_data.get("Användning", ""))
+        template.add_parameter("community", template_data.get(
+            "Gemenskapen",
+            ""
+        ))
+        template.add_parameter("enabling", template_data.get(
+            "Möjliggörande",
+            ""
+        ))
 
         page.text = template.multiline_string() + \
             "\n<noinclude>{{Dokumentation}}</noinclude>"


### PR DESCRIPTION
The columns in the table changes so that now there is a column for active projects rather than inactive. Projects are skipped if they don't have that cell set to 1.