### PR TITLE
Add link to wiki from Phabricator project

### DIFF
--- a/phab.py
+++ b/phab.py
@@ -86,6 +86,7 @@ class Phab:
                 }
             }
             if self._dry_run:
+                logging.debug(f"MOCK REQUEST: {parameters}")
                 project_id = 1
             else:
                 response = self._make_request("project.edit", parameters)

--- a/phab.py
+++ b/phab.py
@@ -4,6 +4,7 @@ from time import sleep, time
 
 import requests
 from dotenv import load_dotenv
+import pywikibot
 
 
 class Phab:
@@ -21,8 +22,9 @@ class Phab:
         Time when last request was made, in seconds.
     """
 
-    def __init__(self, config, dry_run):
-        self._config = config
+    def __init__(self, main_config, dry_run):
+        self._config = main_config.get("phab")
+        self._wiki_config = main_config.get("wiki")
         self._dry_run = dry_run
         self._last_request_time = 0.0
         load_dotenv()
@@ -62,6 +64,10 @@ class Phab:
                 )
             )
         else:
+            siteinfo = pywikibot.Site().siteinfo
+            wiki_url = f"{siteinfo.get('server')}{siteinfo.get('articlepath').removesuffix('$1').removesuffix('/')}"
+            project_namespace = self._wiki_config.get("project_namespace")
+            description = f"//[[{wiki_url}/{project_namespace}:{name_sv} | More project information (in Swedish)]]//\n\n{description}"
             parameters = {
                 "transactions": {
                     "0": {

--- a/phab.py
+++ b/phab.py
@@ -2,9 +2,9 @@ import logging
 import os
 from time import sleep, time
 
+import pywikibot
 import requests
 from dotenv import load_dotenv
-import pywikibot
 
 
 class Phab:

--- a/phab.py
+++ b/phab.py
@@ -64,10 +64,7 @@ class Phab:
                 )
             )
         else:
-            siteinfo = pywikibot.Site().siteinfo
-            wiki_url = f"{siteinfo.get('server')}{siteinfo.get('articlepath').removesuffix('$1').removesuffix('/')}"
-            project_namespace = self._wiki_config.get("project_namespace")
-            description = f"//[[{wiki_url}/{project_namespace}:{name_sv} | More project information (in Swedish)]]//\n\n{description}"
+            description = self._make_description(description, name_sv)
             parameters = {
                 "transactions": {
                     "0": {
@@ -285,6 +282,31 @@ class Phab:
             return None
         else:
             return response["result"]["data"][0]["id"]
+
+    def _make_description(self, description, name_sv):
+        """Make a project description.
+
+        Adds a link to the wiki project page at the start.
+
+        Parameters
+        ----------
+        description : str
+            Text to use in description.
+        name_sv : str
+            Project name in Swedish.
+
+        Returns
+        -------
+        str
+            Project description.
+        """
+        siteinfo = pywikibot.Site().siteinfo
+        article_path = (siteinfo.get('articlepath').removesuffix('$1')
+                        .removesuffix('/'))
+        wiki_url = f"{siteinfo.get('server')}{article_path}"
+        project_namespace = self._wiki_config.get("project_namespace")
+        return (f"//[[{wiki_url}/{project_namespace}:{name_sv} | "
+                f"More project information (in Swedish)]]//\n\n{description}")
 
 
 class PhabApiError(Exception):

--- a/project_start.py
+++ b/project_start.py
@@ -416,7 +416,7 @@ if __name__ == "__main__":
         components,
         args.prompt_add_pages
     )
-    phab = Phab(config["phab"], args.dry_run)
+    phab = Phab(config, args.dry_run)
 
     with open(args.project_file[0], newline="") as file_:
         projects_reader = csv.DictReader(file_, delimiter="\t")

--- a/tests/test_phab.py
+++ b/tests/test_phab.py
@@ -58,7 +58,7 @@ class TestPhab(unittest.TestCase):
             "transactions[1][value][0]") == "Parent-Projekt-på-svenska"
         assert edit_arguments.get("transactions[2][type]") == "description"
         assert edit_arguments.get(
-            "transactions[2][value]") == "//[[//se.wikimedia.org/wiki/Project:Projekt på svenska | More project information (in Swedish)]]//\n\nDescription of the project."
+            "transactions[2][value]") == "//[[//se.wikimedia.org/wiki/Project:Projekt på svenska | More project information (in Swedish)]]//\n\nDescription of the project."  # noqa: E501
         assert edit_arguments.get("transactions[3][type]") == "parent"
         assert edit_arguments.get(
             "transactions[3][value]") == "PHID-PROJ-abc123"

--- a/tests/test_phab.py
+++ b/tests/test_phab.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+import pywikibot
+
 from phab import Phab
 
 
@@ -41,6 +43,8 @@ class TestPhab(unittest.TestCase):
                 return mock_phab_request(result_object=result_object)
 
         mock_requests.post.side_effect = mock_post
+        pywikibot.config.family = "wikimediachapter"
+        pywikibot.config.mylang = "se"
         name_en = "Project in English"
         name_sv = "Projekt på svenska"
         description = "Description of the project."

--- a/tests/test_phab.py
+++ b/tests/test_phab.py
@@ -6,17 +6,19 @@ from phab import Phab
 
 class TestPhab(unittest.TestCase):
 
-    def setUp(self):
-        parameters = [None] * 2
-        self._phab = Phab(*parameters)
-
     @patch("phab.requests")
     def test_add_project(self, mock_requests):
-        self._phab._config = {
-            "parent_project_id": 1,
-            "request_delay": 0,
-            "api_url": "http://site.url"
+        config = {
+            "phab": {
+                "parent_project_id": 1,
+                "request_delay": 0,
+                "api_url": "http://site.url"
+            },
+            "wiki": {
+                "project_namespace": "Project"
+            }
         }
+        self._phab = Phab(config, False)
 
         def mock_post(url, data):
             if url.endswith("/project.search"):
@@ -39,8 +41,8 @@ class TestPhab(unittest.TestCase):
                 return mock_phab_request(result_object=result_object)
 
         mock_requests.post.side_effect = mock_post
-        name_en = "Project-in-English"
-        name_sv = "Projekt-på-svenska"
+        name_en = "Project in English"
+        name_sv = "Projekt på svenska"
         description = "Description of the project."
 
         result = self._phab.add_project(name_en, name_sv, description)
@@ -56,7 +58,7 @@ class TestPhab(unittest.TestCase):
             "transactions[1][value][0]") == "Parent-Projekt-på-svenska"
         assert edit_arguments.get("transactions[2][type]") == "description"
         assert edit_arguments.get(
-            "transactions[2][value]") == "Description of the project."
+            "transactions[2][value]") == "//[[//se.wikimedia.org/wiki/Project:Projekt på svenska | More project information (in Swedish)]]//\n\nDescription of the project."
         assert edit_arguments.get("transactions[3][type]") == "parent"
         assert edit_arguments.get(
             "transactions[3][value]") == "PHID-PROJ-abc123"

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,5 @@ commands = isort {toxinidir}/ {posargs:--check-only --diff} --skip-gitignore
 [isort]
 known_first_party =
 known_third_party = requests,yaml
-known_pywikibot = pywikibot
 multi_line_output = 3
-sections = FUTURE,STDLIB,THIRDPARTY,PYWIKIBOT,FIRSTPARTY,LOCALFOLDER
+sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER


### PR DESCRIPTION
Adds a link at the top of the description of every Phabricator project pointing to the project page on the wiki.

Bug: T378929